### PR TITLE
More robust dependency caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,8 @@ jobs:
         # Download and cache dependencies
         - restore_cache:
             keys:
-            - v1-dependencies-{{ checksum "package.json" }}
+            - v1-dependencies-{{ checksum "package-lock.json" }}
+            - v1-dependencies-
 
         - run:
             name: Installing Dependencies
@@ -23,7 +24,7 @@ jobs:
         - save_cache:
             paths:
                 - node_modules
-            key: v1-dependencies-{{ checksum "package.json" }}
+            key: v1-dependencies-{{ checksum "package-lock.json" }}
 
         - run:
             name: Building Templates


### PR DESCRIPTION
The CircleCI build currently throws errors because:

- it can't cache/restore cache, because there is no `package.json` (it's optional, but our CircleCI config does not know that)
- it generates a file somewhere (we have to find that file)